### PR TITLE
Add npm 7 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ const pushAllReports = async () => {
 			{
 				title: 'Dependencies',
 				type: 'NUMBER',
-				value: audit.metadata.dependencies
+				value: audit.metadata.dependencies.total ?? audit.metadata.dependencies
 			},
 			{
 				title: 'Safe to merge?',

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ const pushAllReports = async () => {
 			{
 				title: 'Dependencies',
 				type: 'NUMBER',
-				value: audit.metadata.dependencies.total ?? audit.metadata.dependencies
+				value: audit.metadata.dependencies.total ?? audit.metadata.totalDependencies
 			},
 			{
 				title: 'Safe to merge?',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpr-npm-audit",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Bitbucket Pipelines report for \"npm audit\".",
   "bin": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpr-npm-audit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Bitbucket Pipelines report for \"npm audit\".",
   "bin": "index.js",
   "repository": {


### PR DESCRIPTION
This PR adds support for new `npm audit --json` format, changed in npm 7. The change is breaking one, meaning that `bpr-npm-audit` doesn't work with npm 7 at the moment.

For reference, here's example `npm audit --json` output for npm 6 (metadata node only):
```json
"metadata": {
  "vulnerabilities": {
    "info": 0,
    "low": 2,
    "moderate": 1,
    "high": 4,
    "critical": 0
  },
  "dependencies": 634,
  "devDependencies": 955,
  "optionalDependencies": 212,
  "totalDependencies": 1796
}
```

Example `npm audit --json` metadata output for npm 7:
```json
"metadata": {
  "vulnerabilities": {
    "info": 0,
    "low": 6,
    "moderate": 1,
    "high": 11,
    "critical": 0,
    "total": 18
  },
  "dependencies": {
    "prod": 685,
    "dev": 956,
    "optional": 153,
    "peer": 0,
    "peerOptional": 0,
    "total": 1788
  }
}
```