### PR TITLE
Truncate details field

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ const pushAllReports = async () => {
 			{
 				annotation_type: 'VULNERABILITY',
 				summary: `${advisory.module_name}: ${advisory.title}`,
-				details: advisory.overview + '\n\n' + advisory.recommendation,
+				details: (advisory.overview + '\n\n' + advisory.recommendation).substring(0, 2000),
 				link: advisory.url,
 				severity: npmSeverityToBitbucketSeverity[advisory.severity]
 			}


### PR DESCRIPTION
One [over-eager package](https://www.npmjs.com/advisories/1780) with a vulnerability had an overview that was 3k+ characters longs. Unfortunately, the Bitbucket details field has a hard limit of 2000 characters. The error we encountered is below:

`Could not push report to Bitbucket. 400 {"key": "report-service.general.bad-request", "message": "The details field cannot contain more than 2000 characters.", "arguments": {}}`

