### PR TITLE
Enable processing large JSON outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pipelines:
   my-pipeline:
     - step:
         script:
-          - BPR_NAME="My Report" BPR_ID="myid" BPR_LEVEL="low" npx bpr-npm-audit
+          - BPR_NAME="My Report" BPR_ID="myid" BPR_LEVEL="low" BPR_MAX_BUFFER_SIZE="20971520" npx bpr-npm-audit
 ```
 
 ### proxy
@@ -73,6 +73,15 @@ Configure by setting the environment variable `BRP_LEVEL` to one of these option
 * `critical`
 
 If there are any vulnerabilities at that level or higher, the report will be marked as failed.
+
+### max buffer size
+
+Configure by setting the environment variable `BPR_MAX_BUFFER_SIZE` to desired value in bytes.
+
+Default: `10485760` (10 MB)
+
+The value shouldn't be changed unless you run into problems with `npm audit` output being too large to handle
+(usually signalled by `Unexpected end of JSON input` error).
 
 ## license
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const reportName = process.env.BPR_NAME || 'Security: npm audit'
 const reportId = process.env.BPR_ID || 'npmaudit'
 const proxyHost = PROXY_TYPES[process.env.BPR_PROXY || 'local']
 const auditLevel = process.env.BPR_LEVEL || 'high'
+const maxAuditOutputBufferSize = Number(process.env.BPR_MAX_BUFFER_SIZE) || 1024 * 1024 * 10
 if (!ORDERED_LEVELS.includes(auditLevel)) {
 	console.error('Unsupported audit level.')
 	process.exit(1)
@@ -52,7 +53,9 @@ if (!proxyHost) {
 }
 
 const startTime = new Date().getTime()
-const { stderr, stdout } = spawnSync('npm', [ 'audit', '--json' ])
+const { stderr, stdout } = spawnSync('npm', [ 'audit', '--json' ], {
+	maxBuffer: maxAuditOutputBufferSize
+})
 if (stderr.toString()) {
 	console.error('Could not execute the `npm audit` command.', stderr.toString())
 	process.exit(1)


### PR DESCRIPTION
Sometimes `npm audit --json` output is so large, that `bpr-npm-audit` breaks on processing it. This is a situation that a repository in my organization encountered recently, when [this issue](https://github.com/advisories/GHSA-4jqc-8m5r-9rpr) popped up - a lot of packages depend on `set-value`, resulting in exceedingly large JSON audit output.

The error then is as follows:

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at Object.<anonymous> (/(...)/index.js:46:20)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
```

Which means `stdout.toString()` outputs truncated JSON, which leads to failure in parsing it properly.

The fix increases max buffer size to enable processing large JSON outputs, while still leaving it configurable in case the default 10 MB buffer causes any problems.

