### PR TITLE
Fixed situation where tasks aren't failing when severity level is met

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ const pushAllReports = async () => {
 		details: 'Results of npm audit.',
 		report_type: 'SECURITY',
 		reporter: bitbucket.owner,
-		result: highestLevelIndex <= ORDERED_LEVELS.indexOf(auditLevel)
+		result: highestLevelIndex < ORDERED_LEVELS.indexOf(auditLevel)
 			? 'PASSED'
 			: 'FAILED',
 		data: [
@@ -143,7 +143,7 @@ const pushAllReports = async () => {
 			{
 				title: 'Safe to merge?',
 				type: 'BOOLEAN',
-				value: highestLevelIndex <= ORDERED_LEVELS.indexOf(auditLevel),
+				value: highestLevelIndex < ORDERED_LEVELS.indexOf(auditLevel),
 			},
 		],
 	})
@@ -215,5 +215,9 @@ const pushAllReports = async () => {
 pushAllReports()
 	.then(() => {
 		console.log('Report successfully pushed to Bitbucket.')
-		process.exit(0)
+		if (highestLevelIndex < ORDERED_LEVELS.indexOf(auditLevel)) {
+			process.exit(0)
+		} else {
+			process.exit(1)
+		}
 	})


### PR DESCRIPTION
Currently the index.js file always ends with `process.exit(0)` which causes it to always report a successful execution.  So I added a condition to end with `process.exit(1)` if the auditLevel is exceeded.  

Also, the documentation states that the severity level should cause a failure when the level specified is met or exceeded, however the conditions in the code for setting the attributes of the annotation use `<=` which is causing to be set to `PASSED` when they should be set to `FAILED`.